### PR TITLE
Makes twoside version have the same bottom margins that oneside versi…

### DIFF
--- a/main_department.tex
+++ b/main_department.tex
@@ -3,5 +3,6 @@
 % Includes blank pages.
 
 \documentclass[twoside, 12pt, doublespace]{ucsbthesis}
+\raggedbottom
 
 \input{main_content.tex}


### PR DESCRIPTION
…on has

I noticed a lot of underfull \vbox warnings that only showed up when compiling main_department.tex. It turns out that the book class has different settings for bottom margins with the twoside option. This just makes the twoside document have the same bottom margins that the oneside document has.

See https://tex.stackexchange.com/questions/337312/changing-book-class-from-one-to-two-sided-changes-size-of-footer

By the way, thanks so much for providing this repo! It's been a huge help.